### PR TITLE
Update #2

### DIFF
--- a/nxengine.sh
+++ b/nxengine.sh
@@ -34,7 +34,7 @@ function build_nxengine-evo() {
     cd ..
     downloadAndExtract "https://www.cavestory.org/downloads/cavestoryen.zip"
     cp -r cavestoryen/CaveStory/data .
-    cp -r cavestoryen/CaveStory/Doukutsu.exe .
+    cp cavestoryen/CaveStory/Doukutsu.exe .
 
     downloadAndExtract "https://github.com/nxengine/translations/releases/download/v1.14/all.zip" "translations"
     cp -r translations/data .

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -28,7 +28,7 @@ function sources_nxengine-evo() {
 function build_nxengine-evo() {
      mkdir build 
      cd build
-     cmake -DCMAKE_BUILD_TYPE=Release -Wno-dev -DCMAKE_INSTALL_PREFIX=/home/pi/RetroPie/roms/ports/CaveStory ..
+     cmake -DCMAKE_BUILD_TYPE=Release -Wno-dev -DCMAKE_INSTALL_PREFIX="$romdir/ports/CaveStory" ..
      make
 
      cd ..
@@ -50,6 +50,6 @@ function install_nxengine-evo() {
 }
 
 function configure_nxengine-evo() {
-    addPort "$md_id" "cavestory" "Cave Story" "/home/pi/RetroPie/roms/ports/CaveStory/bin/nxengine-evo"
-       chown -R $user:$user "/home/pi/RetroPie/roms/ports/CaveStory"
+    addPort "$md_id" "cavestory" "Cave Story" "$romdir/ports/CaveStory/bin/nxengine-evo"
+       chown -R $user:$user "$romdir/ports/CaveStory"
 }

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -12,6 +12,7 @@
 rp_module_id="nxengine-evo"
 rp_module_desc="Cave Story engine clone - NXEngine-Evo"
 rp_module_licence="GPL3 http://nxengine.sourceforge.net/LICENSE"
+rp_module_repo="git https://github.com/nxengine/nxengine-evo.git"
 rp_module_help=""
 rp_module_section="opt"
 rp_module_flags="!armv6 !mali"
@@ -21,7 +22,7 @@ function depends_nxengine-evo() {
 }
 
 function sources_nxengine-evo() {
-   git clone https://github.com/nxengine/nxengine-evo.git
+    gitPullOrClone
 }
 
 function build_nxengine-evo() {

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -11,9 +11,9 @@
 
 rp_module_id="nxengine-evo"
 rp_module_desc="Cave Story engine clone - NXEngine-Evo"
+rp_module_help="NXEngine by Caitlin Shaw, refactoring by isage et al."
 rp_module_licence="GPL3 http://nxengine.sourceforge.net/LICENSE"
 rp_module_repo="git https://github.com/nxengine/nxengine-evo.git"
-rp_module_help="NXEngine by Caitlin Shaw, refactoring by isage et al."
 rp_module_section="opt"
 rp_module_flags="!armv6 !mali"
 

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -33,11 +33,11 @@ function build_nxengine-evo() {
 
     cd ..
     downloadAndExtract "https://www.cavestory.org/downloads/cavestoryen.zip"
-    cp -r cavestoryen/CaveStory/data/ ./
-    cp -r cavestoryen/CaveStory/Doukutsu.exe ./
+    cp -r cavestoryen/CaveStory/data/ .
+    cp -r cavestoryen/CaveStory/Doukutsu.exe .
 
     downloadAndExtract "https://github.com/nxengine/translations/releases/download/v1.14/all.zip" "translations"
-    cp -r translations/data ./
+    cp -r translations/data .
 
     build/nxextract
 }

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -18,7 +18,7 @@ rp_module_section="opt"
 rp_module_flags="!armv6 !mali"
 
 function depends_nxengine-evo() {
-   sudo apt install build-essential libpng-dev libjpeg-dev make cmake cmake-data libsdl2-dev libsdl2-doc libsdl2-gfx-dev libsdl2-gfx-doc libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev 
+   getDepends build-essential libpng-dev libjpeg-dev make cmake cmake-data libsdl2-dev libsdl2-doc libsdl2-gfx-dev libsdl2-gfx-doc libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev 
 }
 
 function sources_nxengine-evo() {

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -26,7 +26,6 @@ function sources_nxengine-evo() {
 }
 
 function build_nxengine-evo() {
-     cd nxengine-evo
      mkdir build 
      cd build
      cmake -DCMAKE_BUILD_TYPE=Release -Wno-dev -DCMAKE_INSTALL_PREFIX=/home/pi/RetroPie/roms/ports/CaveStory ..

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -18,7 +18,7 @@ rp_module_section="opt"
 rp_module_flags="!armv6 !mali"
 
 function depends_nxengine-evo() {
-   sudo apt install build-essential libpng-dev libjpeg-dev make cmake cmake-data git libsdl2-dev libsdl2-doc libsdl2-gfx-dev libsdl2-gfx-doc libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev 
+   sudo apt install build-essential libpng-dev libjpeg-dev make cmake cmake-data libsdl2-dev libsdl2-doc libsdl2-gfx-dev libsdl2-gfx-doc libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev 
 }
 
 function sources_nxengine-evo() {

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -18,7 +18,7 @@ rp_module_section="opt"
 rp_module_flags="!armv6 !mali"
 
 function depends_nxengine-evo() {
-    getDepends build-essential libpng-dev libjpeg-dev make cmake cmake-data libsdl2-dev libsdl2-doc libsdl2-gfx-dev libsdl2-gfx-doc libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev 
+    getDepends libpng-dev libjpeg-dev cmake libsdl2-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev 
 }
 
 function sources_nxengine-evo() {

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -33,8 +33,8 @@ function build_nxengine-evo() {
 
      cd ..
      downloadAndExtract "https://www.cavestory.org/downloads/cavestoryen.zip"
-     cp -r CaveStory/data/ ./
-	cp -r CaveStory/Doukutsu.exe ./
+     cp -r cavestoryen/CaveStory/data/ ./
+	cp -r cavestoryen/CaveStory/Doukutsu.exe ./
 
     downloadAndExtract "https://github.com/nxengine/translations/releases/download/v1.14/all.zip" "translations"
     cp -r translations/data ./

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -14,7 +14,7 @@ rp_module_desc="Cave Story engine clone - NXEngine-Evo"
 rp_module_help="NXEngine by Caitlin Shaw, refactoring by isage et al."
 rp_module_licence="GPL3 http://nxengine.sourceforge.net/LICENSE"
 rp_module_repo="git https://github.com/nxengine/nxengine-evo.git"
-rp_module_section="opt"
+rp_module_section="exp"
 rp_module_flags="!armv6 !mali"
 
 function depends_nxengine-evo() {

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -32,13 +32,11 @@ function build_nxengine-evo() {
      make
 
      cd ..
-     wget "https://www.cavestory.org/downloads/cavestoryen.zip"
-     unzip cavestoryen.zip
+     downloadAndExtract "https://www.cavestory.org/downloads/cavestoryen.zip"
      cp -r CaveStory/data/ ./
 	cp -r CaveStory/Doukutsu.exe ./
 
-    wget "https://github.com/nxengine/translations/releases/download/v1.14/all.zip"
-    mkdir translations && unzip all.zip -d translations
+    downloadAndExtract "https://github.com/nxengine/translations/releases/download/v1.14/all.zip" "translations"
     cp -r translations/data ./
 
 	build/nxextract

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -13,7 +13,7 @@ rp_module_id="nxengine-evo"
 rp_module_desc="Cave Story engine clone - NXEngine-Evo"
 rp_module_licence="GPL3 http://nxengine.sourceforge.net/LICENSE"
 rp_module_repo="git https://github.com/nxengine/nxengine-evo.git"
-rp_module_help=""
+rp_module_help="NXEngine by Caitlin Shaw, refactoring by isage et al."
 rp_module_section="opt"
 rp_module_flags="!armv6 !mali"
 

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -46,7 +46,7 @@ function build_nxengine-evo() {
 
 function install_nxengine-evo() {
      cd nxengine-evo/build
-	sudo make install
+	make install
 }
 
 function configure_nxengine-evo() {

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -18,7 +18,7 @@ rp_module_section="opt"
 rp_module_flags="!armv6 !mali"
 
 function depends_nxengine-evo() {
-   getDepends build-essential libpng-dev libjpeg-dev make cmake cmake-data libsdl2-dev libsdl2-doc libsdl2-gfx-dev libsdl2-gfx-doc libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev 
+    getDepends build-essential libpng-dev libjpeg-dev make cmake cmake-data libsdl2-dev libsdl2-doc libsdl2-gfx-dev libsdl2-gfx-doc libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev 
 }
 
 function sources_nxengine-evo() {
@@ -26,28 +26,28 @@ function sources_nxengine-evo() {
 }
 
 function build_nxengine-evo() {
-     mkdir build 
-     cd build
-     cmake -DCMAKE_BUILD_TYPE=Release -Wno-dev -DCMAKE_INSTALL_PREFIX="$romdir/ports/CaveStory" ..
-     make
+    mkdir build 
+    cd build
+    cmake -DCMAKE_BUILD_TYPE=Release -Wno-dev -DCMAKE_INSTALL_PREFIX="$romdir/ports/CaveStory" ..
+    make
 
-     cd ..
-     downloadAndExtract "https://www.cavestory.org/downloads/cavestoryen.zip"
-     cp -r cavestoryen/CaveStory/data/ ./
-	cp -r cavestoryen/CaveStory/Doukutsu.exe ./
+    cd ..
+    downloadAndExtract "https://www.cavestory.org/downloads/cavestoryen.zip"
+    cp -r cavestoryen/CaveStory/data/ ./
+    cp -r cavestoryen/CaveStory/Doukutsu.exe ./
 
     downloadAndExtract "https://github.com/nxengine/translations/releases/download/v1.14/all.zip" "translations"
     cp -r translations/data ./
 
-	build/nxextract
+    build/nxextract
 }
 
 function install_nxengine-evo() {
-     cd "$md_build/build"
-	make install
+    cd "$md_build/build"
+    make install
 }
 
 function configure_nxengine-evo() {
     addPort "$md_id" "cavestory" "Cave Story" "$romdir/ports/CaveStory/bin/nxengine-evo"
-       chown -R $user:$user "$romdir/ports/CaveStory"
+    chown -R $user:$user "$romdir/ports/CaveStory"
 }

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -33,7 +33,7 @@ function build_nxengine-evo() {
 
     cd ..
     downloadAndExtract "https://www.cavestory.org/downloads/cavestoryen.zip"
-    cp -r cavestoryen/CaveStory/data/ .
+    cp -r cavestoryen/CaveStory/data .
     cp -r cavestoryen/CaveStory/Doukutsu.exe .
 
     downloadAndExtract "https://github.com/nxengine/translations/releases/download/v1.14/all.zip" "translations"

--- a/nxengine.sh
+++ b/nxengine.sh
@@ -45,7 +45,7 @@ function build_nxengine-evo() {
 }
 
 function install_nxengine-evo() {
-     cd nxengine-evo/build
+     cd "$md_build/build"
 	make install
 }
 


### PR DESCRIPTION
(Continuation of #1)

Functionally, this should be almost identical to what you had initially. It extracts `cavestoryen.zip` to a different location, and it discludes the two `*-docs` packages in the depends (the other removed ones are still there, they're just installed automatically either as dependencies of something else we already install or of RetroPie itself, so they don't need to be explicitly stated.)

Next I will be looking into why my display and gamepad don't work right.