### PR TITLE
Use RP's inbuilt install function.

### DIFF
--- a/nxengine.sh
+++ b/nxengine.sh
@@ -28,7 +28,7 @@ function sources_nxengine-evo() {
 function build_nxengine-evo() {
     mkdir build 
     cd build
-    cmake -DCMAKE_BUILD_TYPE=Release -Wno-dev -DCMAKE_INSTALL_PREFIX="$romdir/ports/CaveStory" ..
+    cmake -DCMAKE_BUILD_TYPE=Release -Wno-dev -DPORTABLE=On ..
     make
 
     cd ..
@@ -43,12 +43,13 @@ function build_nxengine-evo() {
 }
 
 function install_nxengine-evo() {
-    cd "$md_build/build"
-    make install
+    md_ret_files=(
+        'build/nxengine-evo'
+        'data'
+    )
 }
 
 function configure_nxengine-evo() {
     moveConfigDir "$home/.local/share/nxengine" "$md_conf_root/cavestory"
-    addPort "$md_id" "cavestory" "Cave Story" "$romdir/ports/CaveStory/bin/nxengine-evo"
-    chown -R $user:$user "$romdir/ports/CaveStory"
+    addPort "$md_id" "cavestory" "Cave Story" "$md_inst/nxengine-evo"
 }


### PR DESCRIPTION
The `md_ret_files` param defines a set of files and directories that will be retained by the installer function. These will be saved to the "module install" directory `$md_inst` (`/opt/retropie/ports/nxengine-evo`).

(`nxextract` only needs run once during installation, right? So we don't need to keep it? If you think it should be retained as well, just add it to the list.)

A couple of changes to account for this:

-- install prefix
++ portable

We are moving the data dir and binary to `$md_inst`; the `-DPORTABLE=On` cmake option has it look for data files in the same dir as the binary, instead of looking in default `/usr/share/nxengine` (or install dir, if defined and portable=off.)

Since we're not using `make install`, I think the `-DCMAKE_INSTALL_PREFIX` is no longer necessary (with portable=on, the output files are identical with or without an install prefix, I checked with `diff -s`.)


--/++ addport command

The `addPort` function's "command" param is changed to use the new binary location.

-- chown

We don't put anything in `$romdir` now so there's nothing to `chown`.