### PR TITLE
Add function `gamedata_nxengine-evo`

### DIFF
--- a/nxengine.sh
+++ b/nxengine.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="nxengine-evo"
 rp_module_desc="Cave Story engine clone - NXEngine-Evo"
-rp_module_help="NXEngine by Caitlin Shaw, refactoring by isage et al."
+rp_module_help="Keyboard required for initial setup, gamepad controls can be configured in game options menu."
 rp_module_licence="GPL3 http://nxengine.sourceforge.net/LICENSE"
 rp_module_repo="git https://github.com/nxengine/nxengine-evo.git"
 rp_module_section="exp" 
@@ -28,31 +28,41 @@ function sources_nxengine-evo() {
 function build_nxengine-evo() {
     mkdir build 
     cd build
-    CFLAGS='-DDATADIR="\"/home/pi/RetroPie/roms/ports/cavestory/data/\""' CXXFLAGS='-DDATADIR="\"/home/pi/RetroPie/roms/ports/cavestory/data/\""' cmake -DCMAKE_BUILD_TYPE=Release -DPORTABLE=On ..
+    CFLAGS='-DDATADIR="\"$romdir/ports/CaveStory/$md_id/data/\""' CXXFLAGS='-DDATADIR="\"$romdir/ports/CaveStory/$md_id/data/\""' cmake -DCMAKE_BUILD_TYPE=Release -DPORTABLE=On ..
     make
-
-    cd ..
-    downloadAndExtract "https://www.cavestory.org/downloads/cavestoryen.zip" "cavestoryen"
-    cp -r cavestoryen/caveStory/data .
-    cp cavestoryen/caveStory/Doukutsu.exe .
-
-    downloadAndExtract "https://github.com/nxengine/translations/releases/download/v1.14/all.zip" "translations"
-    cp -r translations/data .
-
-    build/nxextract
+    md_ret_require=(
+        '$md_build/build/nxengine-evo'
+        '$md_build/build/nxextract'
+    (
 }
 
 function install_nxengine-evo() {
-   md_ret_files=(
+    md_ret_files=(
         'build/nxengine-evo'
+        'build/nxextract'
+        'data'
     )
-   mkRomDir "ports/caveStory"
-   cp -r data "$romdir/ports/caveStory"
+}
+
+function gamedata_nxengine-evo() {
+    if [[ ! -f "$romdir/ports/CaveStory/$md_id/Doukutsu.exe" ]]; then 
+        downloadAndExtract "https://cavestory.org/downloads/cavestoryen.zip" "$romdir/ports/CaveStory/$md_id"
+        mv "$romdir/ports/CaveStory/$md_id/CaveStory/*" "$romdir/ports/CaveStory/$md_id"
+        rmdir "$romdir/ports/CaveStory/$md_id/CaveStory"
+    fi
+    [[ ! -d "$romdir/ports/CaveStory/$md_id/data/lang" ]] && downloadAndExtract "https://github.com/nxengine/translations/releases/download/v1.14/all.zip" "$romdir/ports/CaveStory/$md_id"
+    if [[ ! -d "$romdir/ports/CaveStory/$md_id/data/mods" ]]; then
+        mkdir -p "$romdir/ports/CaveStory/$md_id/data/mods"
+        download "https://github.com/nxengine/nxengine-evo/releases/download/v2.6.5/boss_rush.zip" "$romdir/ports/CaveStory/$md_id/mods/boss_rush.zip"
+    fi
+    cp -r "$md_inst/data" "$romdir/ports/CaveStory/$md_id"
+    pushd "$romdir/ports/CaveStory/$md_id"; "$md_inst/nxextract"; popd
+    chown -R $user:$user "$romdir/ports/CaveStory/$md_id"
 }
 
 function configure_nxengine-evo() {
-    moveConfigDir "$home/.local/share/nxengine" "$md_conf_root/cavestory"
+    [[ "$md_mode" == "install" ]] && gamedata_nxengine-evo
     addPort "$md_id" "cavestory" "Cave Story" "$md_inst/nxengine-evo"
-    chown -R $user:$user "$romdir/ports/caveStory"
+    mkRomDir "ports/CaveStory"
+    moveConfigDir "$home/.local/share/nxengine" "$md_conf_root/cavestory"
 }
-


### PR DESCRIPTION
Playing nice with the libretro port: if a user (me) already has the libretro port installed, then they have a `$romdir/ports/CaveStory` dir with the `data/` dir and `Doukutsu.exe` inside. ~~I think we can work with that.~~

(Actually after testing this, it seems we can't share the data dir with `lr-nxengine`; no files are changed or removed by `-evo`, only added, but when those additional files are present, then `lr-` won't load for me.)

So we'll need a separate data dir than what the `lr-` port uses, but `ports/CaveStory` is already there so do we put something inside of that, instead of using a separate `caveStory` with a little c? `CaveStory/nxengine-evo/data/` for example.

I'm thinking something like this:

First, in the **build** function:

`$romdir` instead of `/home/pi/...` in case they have manually installed RetroPie and have a different username or install path. Data dir path within the rom dir changed as discussed above.

 let's *just* build the binaries here and then, taking a cue from other modules like `quake`, we'll download the game data later on, during the `configure` function.

The `md_ret_require` var functions similar to `md_ret_files`; here, it's a list of files that must exist after the build process. If any of them do not exist then the module is aborted without invoking the remaining steps. Note the slightly different syntax: full path with `$md_build` here, vs. path relative *to* `$md_build` in the other one.

We are going to "retain" the `data` dir in a minute, but we don't "require" it here because, we didn't build it. It just came whole cloth with the repo which we can assume was cloned correctly, or else would have already errored out before we got to this point. We only need to check the files we actually build.

**Install**: (retain both binaries and the `data` dir to use later on during `configure`.)

New function **gamedata_nxengine-evo**: will be called during **configure**. Downloads game data, language packs, and sample mod if necessary, then copies the `-evo` repo data, extracts, and `chown`s. Step by step:

IF NOT EXIST FILE `Doukutsu.exe` THEN download the game data and extract it to `$md_id`. The archive extracts to `./CaveStory` which is not where we want it, so we have to move all of its contents up one level and then delete the empty dir. (If Doukutsu.exe exists, we'll just assume the whole archive is there without checking for every file individually.)

IF NOT EXIST DIR `data/lang` THEN download the translations and extract them to `$md_id`. The archive extracts to `./data/lang` which *is* right where we want it, this time, so we don't need to move anything. (If they already have a `lang/` dir we will assume they have manually added one or more language packs and do not need the complete set to be installed, or it has already been installed.)

IF NOT EXIST DIR `data/mods` THEN create the dir and download sample mod (I haven't got to test this yet; do the mods need unzipped, or just drop them in whole like this? In any case, if the `mods` dir exists, we'll assume they have already manually added one or more mods -- or configured once before and so already have the sample mod -- and so won't download it again. I could use `mkUserDir` or even `mkRomDir` functions to create the `mods` dir here, but the whole thing is about to get `chown`ed here in a second, so it doesn't really matter how we make it.)

IN ANY CASE: Copy the additional data from nx-evo into the rom dir's data dir, then extract remaining data from Doukutsu and `chown` the directory.

**Configure**: 

    [[ "$md_mode" == "install" ]] && gamedata_nxengine-evo

We don't need to download or extract the game data if the module is running in "remove" mode. `chown` was moved to `gamedata` function.