### PR TITLE
Working build function.

### DIFF
--- a/nxengine-evo.sh
+++ b/nxengine-evo.sh
@@ -52,8 +52,7 @@ function gamedata_nxengine-evo() {
     fi
     [[ ! -d "$romdir/ports/CaveStory/$md_id/data/lang" ]] && downloadAndExtract "https://github.com/nxengine/translations/releases/download/v1.14/all.zip" "$romdir/ports/CaveStory/$md_id"
     if [[ ! -d "$romdir/ports/CaveStory/$md_id/data/mods" ]]; then
-        mkdir -p "$romdir/ports/CaveStory/$md_id/data/mods"
-        download "https://github.com/nxengine/nxengine-evo/releases/download/v2.6.5/boss_rush.zip" "$romdir/ports/CaveStory/$md_id/data/mods"
+        downloadAndExtract "https://github.com/nxengine/nxengine-evo/releases/download/v2.6.5/boss_rush.zip" "$romdir/ports/CaveStory/$md_id"
     fi
     cp -r "$md_inst/data" "$romdir/ports/CaveStory/$md_id"
     pushd "$romdir/ports/CaveStory/$md_id"; "$md_inst/nxextract"; popd

--- a/nxengine-evo.sh
+++ b/nxengine-evo.sh
@@ -14,11 +14,11 @@ rp_module_desc="Cave Story engine clone - NXEngine-Evo"
 rp_module_help="Keyboard required for initial setup, gamepad controls can be configured in game options menu."
 rp_module_licence="GPL3 http://nxengine.sourceforge.net/LICENSE"
 rp_module_repo="git https://github.com/nxengine/nxengine-evo.git"
-rp_module_section="exp" 
+rp_module_section="exp"
 rp_module_flags="!armv6 !mali"
 
 function depends_nxengine-evo() {
-    getDepends libpng-dev libjpeg-dev cmake libsdl2-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev 
+    getDepends libpng-dev libjpeg-dev cmake libsdl2-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev
 }
 
 function sources_nxengine-evo() {
@@ -26,14 +26,14 @@ function sources_nxengine-evo() {
 }
 
 function build_nxengine-evo() {
-    mkdir build 
+    mkdir build
     cd build
     CFLAGS='-DDATADIR="\"$romdir/ports/CaveStory/$md_id/data/\""' CXXFLAGS='-DDATADIR="\"$romdir/ports/CaveStory/$md_id/data/\""' cmake -DCMAKE_BUILD_TYPE=Release -DPORTABLE=On ..
     make
     md_ret_require=(
-        '$md_build/build/nxengine-evo'
-        '$md_build/build/nxextract'
-    (
+        "$md_build/build/nxengine-evo"
+        "$md_build/build/nxextract"
+    )
 }
 
 function install_nxengine-evo() {
@@ -45,7 +45,7 @@ function install_nxengine-evo() {
 }
 
 function gamedata_nxengine-evo() {
-    if [[ ! -f "$romdir/ports/CaveStory/$md_id/Doukutsu.exe" ]]; then 
+    if [[ ! -f "$romdir/ports/CaveStory/$md_id/Doukutsu.exe" ]]; then
         downloadAndExtract "https://cavestory.org/downloads/cavestoryen.zip" "$romdir/ports/CaveStory/$md_id"
         mv "$romdir/ports/CaveStory/$md_id/CaveStory/*" "$romdir/ports/CaveStory/$md_id"
         rmdir "$romdir/ports/CaveStory/$md_id/CaveStory"

--- a/nxengine-evo.sh
+++ b/nxengine-evo.sh
@@ -47,7 +47,7 @@ function install_nxengine-evo() {
 function gamedata_nxengine-evo() {
     if [[ ! -f "$romdir/ports/CaveStory/$md_id/Doukutsu.exe" ]]; then
         downloadAndExtract "https://cavestory.org/downloads/cavestoryen.zip" "$romdir/ports/CaveStory/$md_id"
-        mv "$romdir/ports/CaveStory/$md_id/CaveStory/*" "$romdir/ports/CaveStory/$md_id"
+        mv "$romdir/ports/CaveStory/$md_id/CaveStory/"* "$romdir/ports/CaveStory/$md_id"
         rmdir "$romdir/ports/CaveStory/$md_id/CaveStory"
     fi
     [[ ! -d "$romdir/ports/CaveStory/$md_id/data/lang" ]] && downloadAndExtract "https://github.com/nxengine/translations/releases/download/v1.14/all.zip" "$romdir/ports/CaveStory/$md_id"

--- a/nxengine-evo.sh
+++ b/nxengine-evo.sh
@@ -53,7 +53,7 @@ function gamedata_nxengine-evo() {
     [[ ! -d "$romdir/ports/CaveStory/$md_id/data/lang" ]] && downloadAndExtract "https://github.com/nxengine/translations/releases/download/v1.14/all.zip" "$romdir/ports/CaveStory/$md_id"
     if [[ ! -d "$romdir/ports/CaveStory/$md_id/data/mods" ]]; then
         mkdir -p "$romdir/ports/CaveStory/$md_id/data/mods"
-        download "https://github.com/nxengine/nxengine-evo/releases/download/v2.6.5/boss_rush.zip" "$romdir/ports/CaveStory/$md_id/mods/boss_rush.zip"
+        download "https://github.com/nxengine/nxengine-evo/releases/download/v2.6.5/boss_rush.zip" "$romdir/ports/CaveStory/$md_id/data/mods"
     fi
     cp -r "$md_inst/data" "$romdir/ports/CaveStory/$md_id"
     pushd "$romdir/ports/CaveStory/$md_id"; "$md_inst/nxextract"; popd

--- a/nxengine-evo.sh
+++ b/nxengine-evo.sh
@@ -28,7 +28,7 @@ function sources_nxengine-evo() {
 function build_nxengine-evo() {
     mkdir build
     cd build
-    CFLAGS='-DDATADIR="\"$romdir/ports/CaveStory/$md_id/data/\""' CXXFLAGS='-DDATADIR="\"$romdir/ports/CaveStory/$md_id/data/\""' cmake -DCMAKE_BUILD_TYPE=Release -DPORTABLE=On ..
+    CFLAGS='-DDATADIR="\"'"$romdir"'/ports/CaveStory/'"$md_id"'/data/\""' CXXFLAGS='-DDATADIR="\"'"$romdir"'/ports/CaveStory/'"$md_id"'/data/\""' cmake -DCMAKE_BUILD_TYPE=Release -DPORTABLE=On ..
     make
     md_ret_require=(
         "$md_build/build/nxengine-evo"

--- a/nxengine-evo.sh
+++ b/nxengine-evo.sh
@@ -63,5 +63,5 @@ function configure_nxengine-evo() {
     [[ "$md_mode" == "install" ]] && gamedata_nxengine-evo
     addPort "$md_id" "cavestory" "Cave Story" "$md_inst/nxengine-evo"
     mkRomDir "ports/CaveStory"
-    moveConfigDir "$home/.local/share/nxengine" "$md_conf_root/cavestory"
+    moveConfigDir "$home/.local/share/nxengine" "$md_conf_root/cavestory/$md_id"
 }

--- a/nxengine-evo.sh
+++ b/nxengine-evo.sh
@@ -18,7 +18,7 @@ rp_module_section="exp"
 rp_module_flags="!armv6 !mali"
 
 function depends_nxengine-evo() {
-    getDepends libpng-dev libjpeg-dev cmake libsdl2-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev
+    getDepends libpng-dev libjpeg-dev cmake libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev
 }
 
 function sources_nxengine-evo() {

--- a/nxengine-evo.sh
+++ b/nxengine-evo.sh
@@ -11,7 +11,7 @@
 
 rp_module_id="nxengine-evo"
 rp_module_desc="Cave Story engine clone - NXEngine-Evo"
-rp_module_help="Keyboard required for initial setup, gamepad controls can be configured in game options menu."
+rp_module_help="Keyboard required for initial setup, gamepad controls can be configured in game options menu.\n\nSet runcommand video mode to match in-game resolution - recommended 640x480."
 rp_module_licence="GPL3 http://nxengine.sourceforge.net/LICENSE"
 rp_module_repo="git https://github.com/nxengine/nxengine-evo.git"
 rp_module_section="exp"


### PR DESCRIPTION
Fixed a typo.

Cleaned up some trailing spaces.

I guess `ret_require` needs "double quotes," not 'single.' (Edit: I guess it's not the function itself but the fact it uses a $variable in the path that requires double quotes; I've learned that double quotes allow var expansion while single quotes interpret them literally.)

Renamed file (repo and module are both named with `-evo`; file probably should be, too.)

-----

Got past the build phase, threw an error downloading the boss rush mod. Investigating now.